### PR TITLE
Add set parameter methods

### DIFF
--- a/src/conn/DBConnection.cpp
+++ b/src/conn/DBConnection.cpp
@@ -12,44 +12,44 @@
 #include <cppconn/prepared_statement.h>
 
 //Data Access Methods
-int DBConnection::prepareStatement(string sql) {    
+int DBConnection::prepareStatement(string sql) {
     _preparedStatement = _connection->prepareStatement(sql);
     return 0;
 }
 
 int DBConnection::deleteStatement() {
-    delete _preparedStatement;    
+    delete _preparedStatement;
     return 0;
 }
 
 int DBConnection::executeStatement() {
-    _preparedStatement->execute(); 
+    _preparedStatement->execute();
     return 0;
 }
 
 sql::ResultSet* DBConnection::executeQuery() {
     sql::ResultSet *res;
-    res = _preparedStatement->executeQuery(); 
+    res = _preparedStatement->executeQuery();
     return res;
 }
-        
+
 //DB Connection Methods
-int DBConnection::connectDB(string host, string user, string password, string schema) {    
+int DBConnection::connectDB(string host, string user, string password, string schema) {
     _host = host;
     _user = user;
     _password = password;
     _schema = schema;
-          
+
     return connect();
 }
 
 int DBConnection::connect() {
     sql::Driver *driver;
     driver = get_driver_instance();
-    
+
     _connection = driver->connect(_host, _user, _password);
     _connection->setSchema(_schema);
-    
+
     return 0;
 }
 
@@ -69,7 +69,7 @@ void DBConnection::setNull(int parameterNumber) {
     _preparedStatement->setNull(parameterNumber, 0);
 }
 
-int DBConnection::setConnection(sql::Connection **connection) {    
+int DBConnection::setConnection(sql::Connection **connection) {
     _connection = *connection;
     return 0;
 }

--- a/src/conn/DBConnection.h
+++ b/src/conn/DBConnection.h
@@ -7,34 +7,34 @@
 using namespace std;
 
 class DBConnection {
-    
-    public:        
+
+    public:
         //Data Access Methods
         int prepareStatement(string sql);
         int deleteStatement();
 
         int executeStatement();
         sql::ResultSet* executeQuery();
-        
+
         void setString(int parameterNumber, string value);
         void setInt(int parameterNumber, int value);
         void setDouble(int parameterNumber, double value);
         void setNull(int parameterNumber);
-        
+
         //DB Connection Methods
         int setConnection(sql::Connection **connection);
         int connectDB(string host, string user, string password, string schema);
         int resetConnection();
         int closeConnection();
-        
-    
+
+
     private:
         //Connection Variables
         sql::Connection *_connection;
         sql::PreparedStatement *_preparedStatement;
-        
+
         string _host, _user, _password, _schema;
-        
+
         int connect();
 };
 

--- a/src/fields/BooleanField.cpp
+++ b/src/fields/BooleanField.cpp
@@ -1,9 +1,9 @@
 #include "BooleanField.h"
 
-BooleanField::BooleanField(string fieldName, bool defaultValue, bool isPrimaryKey, bool isUnique, bool isNullable): 
-    Field(fieldName, BOOLEAN, isPrimaryKey, isUnique, isNullable) { 
+BooleanField::BooleanField(string fieldName, bool defaultValue, bool isPrimaryKey, bool isUnique, bool isNullable):
+    Field(fieldName, BOOLEAN, isPrimaryKey, isUnique, isNullable) {
     _fieldValue = defaultValue;
-} 
+}
 
 void BooleanField::setValue(bool value) {
     setNull(false);

--- a/src/fields/BooleanField.cpp
+++ b/src/fields/BooleanField.cpp
@@ -13,3 +13,7 @@ void BooleanField::setValue(bool value) {
 bool BooleanField::getValue() {
     return _fieldValue;
 }
+
+void BooleanField::setParameter(int parameterNumber, DBConnection connection) {
+    connection.setInt(parameterNumber, getValue());
+}

--- a/src/fields/BooleanField.h
+++ b/src/fields/BooleanField.h
@@ -6,16 +6,16 @@
 using namespace std;
 
 class BooleanField: public Field {
-    
+
     private:
         bool _fieldValue;
-        
+
     public:
         BooleanField(string fieldName, bool defaultValue=false, bool isPrimaryKey=false, bool isUnique=false, bool isNullable=true);
-        
+
         void setValue(bool value);
         bool getValue();
-        
+
         void setParameter(int parameterNumber, DBConnection connection);
 };
 

--- a/src/fields/BooleanField.h
+++ b/src/fields/BooleanField.h
@@ -15,6 +15,8 @@ class BooleanField: public Field {
         
         void setValue(bool value);
         bool getValue();
+        
+        void setParameter(int parameterNumber, DBConnection connection);
 };
 
 #endif

--- a/src/fields/CharField.cpp
+++ b/src/fields/CharField.cpp
@@ -2,10 +2,10 @@
 #include <stdexcept>
 
 CharField::CharField(string fieldName, int maxLength, string defaultValue, bool isPrimaryKey, bool isUnique, bool isNullable):
-    Field(fieldName, CHAR, isPrimaryKey, isUnique, isNullable) { 
+    Field(fieldName, CHAR, isPrimaryKey, isUnique, isNullable) {
     _fieldValue = defaultValue;
     _maxLength = maxLength;
-} 
+}
 
 void CharField::setValue(string value) {
     setNull(false);
@@ -25,7 +25,7 @@ string CharField::checkMaxLength(string newValue) {
     if (newValue.length() > _maxLength) {
         throw length_error("Field value exeeds the maximum allowed length");
     }
-    return newValue;            
+    return newValue;
 }
 
 void CharField::setParameter(int parameterNumber, DBConnection connection) {

--- a/src/fields/CharField.cpp
+++ b/src/fields/CharField.cpp
@@ -27,3 +27,7 @@ string CharField::checkMaxLength(string newValue) {
     }
     return newValue;            
 }
+
+void CharField::setParameter(int parameterNumber, DBConnection connection) {
+    connection.setString(parameterNumber, getValue());
+}

--- a/src/fields/CharField.h
+++ b/src/fields/CharField.h
@@ -20,6 +20,8 @@ class CharField: public Field {
 
         int getMaxLength();
         string checkMaxLength(string newValue);
+
+        void setParameter(int parameterNumber, DBConnection connection);
 };
 
 #endif

--- a/src/fields/CharField.h
+++ b/src/fields/CharField.h
@@ -7,14 +7,14 @@
 using namespace std;
 
 class CharField: public Field {
-    
+
     private:
         string _fieldValue;
         unsigned int _maxLength;
-        
+
     public:
         CharField(string fieldName, int maxLength, string defaultValue="", bool isPrimaryKey=false, bool isUnique=false, bool isNullable=true);
-        
+
         void setValue(string value);
         string getValue();
 

--- a/src/fields/Field.h
+++ b/src/fields/Field.h
@@ -7,12 +7,12 @@
 
 using namespace std;
 
-enum FieldType { 
-    INTEGER, FLOAT, TEXT, CHAR, BOOLEAN 
+enum FieldType {
+    INTEGER, FLOAT, TEXT, CHAR, BOOLEAN
 };
 
 class Field {
-    
+
     private:
         string _fieldName;
         FieldType _fieldType;
@@ -21,17 +21,17 @@ class Field {
         bool _isNullable;
         bool _isNull;
         bool _isAutoFilled;
-    
+
     public:
         Field(string fieldName, FieldType fieldType, bool isPrimaryKey=false, bool isUnique=false, bool isNullable=true, bool isAutoFilled=false);
-        
-        string getName();        
-        FieldType getType();        
-        bool isUnique();        
-        bool isPrimaryKey();        
-        bool isAutoFilled();        
-        bool isNullable();        
-        bool isNull();        
+
+        string getName();
+        FieldType getType();
+        bool isUnique();
+        bool isPrimaryKey();
+        bool isAutoFilled();
+        bool isNullable();
+        bool isNull();
         void setNull(bool isNull);
 
         virtual void setParameter(int parameterNumber, DBConnection connection) = 0;

--- a/src/fields/Field.h
+++ b/src/fields/Field.h
@@ -34,11 +34,7 @@ class Field {
         bool isNull();        
         void setNull(bool isNull);
 
-        virtual void setParameter(int parameterNumber, DBConnection connection);
-    
-    // protected:
-        
-    //     DBConnection _connection;
+        virtual void setParameter(int parameterNumber, DBConnection connection) = 0;
 };
 
 #endif

--- a/src/fields/Field.h
+++ b/src/fields/Field.h
@@ -1,6 +1,8 @@
 #ifndef FIELD_H
 #define FIELD_H
 
+#include "../conn/DBConnection.h"
+
 #include <string>
 
 using namespace std;
@@ -31,6 +33,12 @@ class Field {
         bool isNullable();        
         bool isNull();        
         void setNull(bool isNull);
+
+        virtual void setParameter(int parameterNumber, DBConnection connection);
+    
+    // protected:
+        
+    //     DBConnection _connection;
 };
 
 #endif

--- a/src/fields/FloatField.cpp
+++ b/src/fields/FloatField.cpp
@@ -1,9 +1,9 @@
 #include "FloatField.h"
 
-FloatField::FloatField(string fieldName, double defaultValue, bool isPrimaryKey, bool isUnique, bool isNullable): 
-    Field(fieldName, FLOAT, isPrimaryKey, isUnique, isNullable) { 
+FloatField::FloatField(string fieldName, double defaultValue, bool isPrimaryKey, bool isUnique, bool isNullable):
+    Field(fieldName, FLOAT, isPrimaryKey, isUnique, isNullable) {
     _fieldValue = defaultValue;
-} 
+}
 
 void FloatField::setValue(double value) {
     setNull(false);

--- a/src/fields/FloatField.cpp
+++ b/src/fields/FloatField.cpp
@@ -13,3 +13,7 @@ void FloatField::setValue(double value) {
 double FloatField::getValue() {
     return _fieldValue;
 }
+
+void FloatField::setParameter(int parameterNumber, DBConnection connection) {
+    connection.setDouble(parameterNumber, getValue());
+}

--- a/src/fields/FloatField.h
+++ b/src/fields/FloatField.h
@@ -6,14 +6,14 @@
 using namespace std;
 
 class FloatField: public Field {
-    
+
     private:
         double _fieldValue;
-        
+
     public:
         FloatField(string fieldName, double defaultValue=0, bool isPrimaryKey=false, bool isUnique=false, bool isNullable=true);
-        
-        void setValue(double value);        
+
+        void setValue(double value);
         double getValue();
 
         void setParameter(int parameterNumber, DBConnection connection);

--- a/src/fields/FloatField.h
+++ b/src/fields/FloatField.h
@@ -15,6 +15,8 @@ class FloatField: public Field {
         
         void setValue(double value);        
         double getValue();
+
+        void setParameter(int parameterNumber, DBConnection connection);
 };
 
 #endif

--- a/src/fields/IntegerField.cpp
+++ b/src/fields/IntegerField.cpp
@@ -1,7 +1,7 @@
 #include "IntegerField.h"
 
-IntegerField::IntegerField(string fieldName, int defaultValue, bool isPrimaryKey, bool isUnique, bool isNullable, bool isAutoIncremented): 
-    Field(fieldName, INTEGER, isPrimaryKey, isUnique, isNullable, isAutoIncremented) { 
+IntegerField::IntegerField(string fieldName, int defaultValue, bool isPrimaryKey, bool isUnique, bool isNullable, bool isAutoIncremented):
+    Field(fieldName, INTEGER, isPrimaryKey, isUnique, isNullable, isAutoIncremented) {
     _fieldValue = defaultValue;
     _isAutoIncremented = isAutoIncremented;
 }

--- a/src/fields/IntegerField.cpp
+++ b/src/fields/IntegerField.cpp
@@ -14,3 +14,7 @@ void IntegerField::setValue(int value) {
 int IntegerField::getValue() {
     return _fieldValue;
 }
+
+void IntegerField::setParameter(int parameterNumber, DBConnection connection) {
+    connection.setInt(parameterNumber, getValue());
+}

--- a/src/fields/IntegerField.h
+++ b/src/fields/IntegerField.h
@@ -16,6 +16,8 @@ class IntegerField: public Field {
         
         void setValue(int value);        
         int getValue();
+        
+        void setParameter(int parameterNumber, DBConnection connection);
 };
 
 #endif

--- a/src/fields/IntegerField.h
+++ b/src/fields/IntegerField.h
@@ -6,17 +6,17 @@
 using namespace std;
 
 class IntegerField: public Field {
-    
+
     private:
         int _fieldValue;
         bool _isAutoIncremented;
-        
+
     public:
         IntegerField(string fieldName, int defaultValue=0, bool isPrimaryKey=false, bool isUnique=false, bool isNullable=true, bool isAutoIncremented=false);
-        
-        void setValue(int value);        
+
+        void setValue(int value);
         int getValue();
-        
+
         void setParameter(int parameterNumber, DBConnection connection);
 };
 

--- a/src/fields/TextField.cpp
+++ b/src/fields/TextField.cpp
@@ -1,9 +1,9 @@
 #include "TextField.h"
 
-TextField::TextField(string fieldName, string defaultValue, bool isPrimaryKey, bool isUnique, bool isNullable): 
-    Field(fieldName, TEXT, isPrimaryKey, isUnique, isNullable) { 
+TextField::TextField(string fieldName, string defaultValue, bool isPrimaryKey, bool isUnique, bool isNullable):
+    Field(fieldName, TEXT, isPrimaryKey, isUnique, isNullable) {
     _fieldValue = defaultValue;
-} 
+}
 
 void TextField::setValue(string value) {
     setNull(false);

--- a/src/fields/TextField.cpp
+++ b/src/fields/TextField.cpp
@@ -13,3 +13,7 @@ void TextField::setValue(string value) {
 string TextField::getValue() {
     return _fieldValue;
 }
+
+void TextField::setParameter(int parameterNumber, DBConnection connection) {
+    connection.setString(parameterNumber, getValue());
+}

--- a/src/fields/TextField.h
+++ b/src/fields/TextField.h
@@ -15,6 +15,8 @@ class TextField: public Field {
         
         void setValue(string value);        
         string getValue();
+        
+        void setParameter(int parameterNumber, DBConnection connection);
 };
 
 #endif

--- a/src/fields/TextField.h
+++ b/src/fields/TextField.h
@@ -6,16 +6,16 @@
 using namespace std;
 
 class TextField: public Field {
-    
+
     private:
         string _fieldValue;
-        
+
     public:
         TextField(string fieldName, string defaultValue="", bool isPrimaryKey=false, bool isUnique=false, bool isNullable=true);
-        
-        void setValue(string value);        
+
+        void setValue(string value);
         string getValue();
-        
+
         void setParameter(int parameterNumber, DBConnection connection);
 };
 

--- a/src/model/Model.cpp
+++ b/src/model/Model.cpp
@@ -90,7 +90,6 @@ int Model::insertBatch(vector<Model*> models, unsigned int batchsize, Mode mode)
                 
                 if (f->isNull()) {
                     _connection.setNull(paramNum);
-                    continue;
                 } else {
                     f->setParameter(paramNum, _connection);
                 }

--- a/src/model/Model.cpp
+++ b/src/model/Model.cpp
@@ -91,39 +91,8 @@ int Model::insertBatch(vector<Model*> models, unsigned int batchsize, Mode mode)
                 if (f->isNull()) {
                     _connection.setNull(paramNum);
                     continue;
-                }
-                    
-                switch(f->getType()) {
-
-                    case INTEGER: {
-                        IntegerField * i = static_cast <IntegerField*>(f);
-                        _connection.setInt(paramNum, i->getValue());
-                        break;
-                    }
-
-                    case FLOAT: {
-                        FloatField * i = static_cast <FloatField*>(f);
-                        _connection.setDouble(paramNum, i->getValue());
-                        break;
-                    }
-                    
-                    case TEXT: {
-                        TextField * i = static_cast <TextField*>(f);
-                        _connection.setString(paramNum, i->getValue());
-                        break;
-                    }
-                    
-                    case CHAR: {
-                        CharField * i = static_cast <CharField*>(f);
-                        _connection.setString(paramNum, i->getValue());
-                        break;
-                    }
-
-                    case BOOLEAN: {
-                        BooleanField * i = static_cast <BooleanField*>(f);
-                        _connection.setInt(paramNum, i->getValue());
-                        break;
-                    }
+                } else {
+                    f->setParameter(paramNum, _connection);
                 }
             }
         }

--- a/src/model/Model.cpp
+++ b/src/model/Model.cpp
@@ -8,86 +8,86 @@ Model::Model(string name) {
 Model::~Model() {
     for (vector<Field*>::const_iterator it = fields.begin(); it != fields.end(); it++) {
         delete *it;
-    } 
+    }
     fields.clear();
 }
 
 IntegerField* Model::integerField(string fieldName, int defaultValue, bool isPrimaryKey, bool isUnique, bool isNullable, bool isAutoIncremented) {
     IntegerField * f = new IntegerField(fieldName, defaultValue, isPrimaryKey, isUnique, isNullable, isAutoIncremented);
     fields.push_back(f);
-    
+
     return f;
 }
 
 FloatField* Model::floatField(string fieldName, double defaultValue, bool isPrimaryKey, bool isUnique, bool isNullable) {
     FloatField * f = new FloatField(fieldName, defaultValue, isPrimaryKey, isUnique, isNullable);
     fields.push_back(f);
-    
+
     return f;
 }
 
 TextField* Model::textField(string fieldName, string defaultValue, bool isPrimaryKey, bool isUnique, bool isNullable) {
     TextField * f = new TextField(fieldName, defaultValue, isPrimaryKey, isUnique, isNullable);
     fields.push_back(f);
-    
+
     return f;
 }
 
 CharField* Model::charField(string fieldName, int maxLength, string defaultValue, bool isPrimaryKey, bool isUnique, bool isNullable) {
     CharField * f = new CharField(fieldName, maxLength, defaultValue, isPrimaryKey, isUnique, isNullable);
     fields.push_back(f);
-    
+
     return f;
 }
 
 BooleanField* Model::booleanField(string fieldName, bool defaultValue, bool isPrimaryKey, bool isUnique, bool isNullable) {
     BooleanField * f = new BooleanField(fieldName, defaultValue, isPrimaryKey, isUnique, isNullable);
     fields.push_back(f);
-    
+
     return f;
 }
 
 int Model::insert(Mode mode) {
     vector<Model*> models;
     models.push_back(this);
-    
+
     return insertBatch(models, 1, mode);
 }
 
 int Model::insertBatch(vector<Model*> models, unsigned int batchsize, Mode mode) {
     unsigned int size = models.size();
-    
+
     if (size < batchsize) {
         batchsize = size;
     }
-        
+
     //workout the size of the last batch
     int rem = size % batchsize;
-    unsigned int finalFullBatch = size - rem;    
-    
-    //generate SQL 
-    string sqlHead; 
-    string sqlBatch; 
-    string sqlUpdate; 
+    unsigned int finalFullBatch = size - rem;
+
+    //generate SQL
+    string sqlHead;
+    string sqlBatch;
+    string sqlUpdate;
     generateSQLParts(sqlHead, sqlBatch, sqlUpdate, mode);
-    
+
     string sqlTail = generateSQLTail(sqlBatch, sqlUpdate, batchsize, mode);
-    
+
     //prepare first statement
     _connection.prepareStatement(sqlHead + sqlTail);
-    
+
     int paramNum = 0;
     bool isFinalBatch = false;
     //iterate through the list of models inserting batches of the specified size
-    for (unsigned int i = 0; i < models.size(); i++) {    
+    for (unsigned int i = 0; i < models.size(); i++) {
         Model * m = models[i];
         //iterate through the list of fields, adding them as parameters
         for (unsigned int j = 0; j < m->fields.size(); j++) {
             Field * f = m->fields[j];
-            
+
             if (!f->isAutoFilled()) {
                 paramNum++;
-                
+
                 if (f->isNull()) {
                     _connection.setNull(paramNum);
                 } else {
@@ -95,26 +95,26 @@ int Model::insertBatch(vector<Model*> models, unsigned int batchsize, Mode mode)
                 }
             }
         }
-                
-        if (i+1 == size || (!isFinalBatch && (i+1) % batchsize == 0)) {        
+
+        if (i+1 == size || (!isFinalBatch && (i+1) % batchsize == 0)) {
             _connection.executeStatement();
-            
+
             //reset paramNum after execution
             paramNum = 0;
-            
+
             //the final batch will require a prepared statement that is only as long as the remaining no. of models
             if (i+1 >= finalFullBatch) {
                 isFinalBatch = true;
-                
+
                 sqlTail = generateSQLTail(sqlBatch, sqlUpdate, rem, mode);
                 batchsize = rem;
             }
-            
-            _connection.deleteStatement();         
+
+            _connection.deleteStatement();
             _connection.prepareStatement(sqlHead + sqlTail);
-        }        
-    }  
-    
+        }
+    }
+
     return 0;
 }
 
@@ -123,12 +123,12 @@ int Model::truncate() {
     _connection.prepareStatement("TRUNCATE " + tableName);
     _connection.executeStatement();
     _connection.deleteStatement();
-    
+
     return 0;
 }
 
 
-int Model::setConnection(DBConnection connection) {    
+int Model::setConnection(DBConnection connection) {
     _connection = connection;
     return 0;
 }
@@ -143,35 +143,35 @@ void Model::generateSQLParts(string &sqlHead, string &sqlBatch, string &sqlUpdat
     string sqlFields = "";
     sqlBatch = "(";
     sqlUpdate = " ON DUPLICATE KEY UPDATE ";
-    
+
     bool isFirstField = true;
-    
+
     for (unsigned int i = 0; i < fields.size(); i++) {
         Field* f = fields[i];
-        
+
         if (!f->isAutoFilled()) {
             if (isFirstField) {
                 isFirstField = false;
-                
+
                 sqlFields += f->getName();
                 sqlBatch += "?";
-                
+
                 if (mode == UPDATE) {
                     sqlUpdate += f->getName() + " = VALUES(" + f->getName() + ")";
                 }
             } else {
                 sqlFields += ", " + f->getName();
                 sqlBatch += ",?";
-                
+
                 if (mode == UPDATE) {
                     sqlUpdate += ", " + f->getName() + " = VALUES(" + f->getName() + ")";
                 }
             }
         }
     }
-    
+
     sqlBatch += ")";
-    
+
     if (mode == IGNORE) {
         sqlHead = "INSERT IGNORE INTO " + tableName + " (" + sqlFields + ") VALUES ";
     } else {
@@ -181,14 +181,14 @@ void Model::generateSQLParts(string &sqlHead, string &sqlBatch, string &sqlUpdat
 
 string Model::generateSQLTail(string sqlBatch, string sqlUpdate, int batchsize, Mode mode) {
     string sqlTail = sqlBatch;
-    
+
     for (int j = 1; j < batchsize; j++) {
         sqlTail += "," + sqlBatch;
     }
-    
+
     if (mode == UPDATE) {
         sqlTail += sqlUpdate;
     }
-    
+
     return sqlTail;
 }

--- a/src/model/Model.h
+++ b/src/model/Model.h
@@ -14,40 +14,40 @@
 
 using namespace std;
 
-enum Mode { 
-    UPDATE, IGNORE 
+enum Mode {
+    UPDATE, IGNORE
 };
 
 class Model {
-    
+
     private:
         void generateSQLParts(string &sqlHead, string &sqlBatch, string &sqlUpdate, Mode mode);
         string generateSQLTail(string sqlBatch, string sqlUpdate, int batchsize, Mode mode);
-        
+
     public:
         Model(string name);
         ~Model();
-        
+
         IntegerField* integerField(string fieldName, int defaultValue=0, bool isPrimaryKey=false, bool isUnique=false, bool isNullable=true, bool isAutoIncremented=false);
         FloatField* floatField(string fieldName, double defaultValue=0, bool isPrimaryKey=false, bool isUnique=false, bool isNullable=true);
         TextField* textField(string fieldName, string defaultValue="", bool isPrimaryKey=false, bool isUnique=false, bool isNullable=true);
         CharField* charField(string fieldName, int maxLength, string defaultValue="", bool isPrimaryKey=false, bool isUnique=false, bool isNullable=true);
         BooleanField* booleanField(string fieldName, bool defaultValue=false, bool isPrimaryKey=false, bool isUnique=false, bool isNullable=true);
-         
+
         int insert(Mode mode=UPDATE);
         int insertBatch(vector<Model*> models, unsigned int batchsize=100, Mode mode=UPDATE);
         int truncate();
-        
+
         template<typename T> Model* getByID(T pk_value);
-        
+
         int setConnection(DBConnection connection);
         DBConnection getConnection();
-        
+
         string tableName;
         vector<Field*> fields;
-        
+
     protected:
-        
+
         DBConnection _connection;
 };
 

--- a/tst/test.cpp
+++ b/tst/test.cpp
@@ -6,14 +6,14 @@ class Protein: public Model {
 
     public:
         Protein(): Model("Proteins") {}
-        
+
         IntegerField * proteinID = integerField ("Protein_ID");
         CharField * proteinChain = charField ("Protein_Chain", 5);
         TextField * proteinName = textField ("Protein_Name");
-        BooleanField * proteinIsDrugTarget = booleanField ("Protein_IsDrugTarget"); 
+        BooleanField * proteinIsDrugTarget = booleanField ("Protein_IsDrugTarget");
 };
 
-//main method    
+//main method
 int main(int argc, const char* argv[] ) {
     Protein m;
     m.proteinID->setValue(1);
@@ -22,7 +22,7 @@ int main(int argc, const char* argv[] ) {
     m.proteinName->setValue("Name");
     m.proteinIsDrugTarget->setValue(true);
 
-    
+
     cout << m.tableName << endl;
     cout << m.proteinID->getValue() << " " << m.proteinID->getName() << endl;
     cout << m.proteinName->getValue() << " " << m.proteinName->getName() << endl;


### PR DESCRIPTION
`setParameter()` member functions created for `Field` classes (virtual function in `Field` class, implemented in the different subclasses)
Switch statement in `Model.cpp` replaced with `setParameter() call.
Continue statement preceding this removed, changed to else. 
Tested by running make.
Issue: https://github.com/davidbrownza/cormap/issues/39